### PR TITLE
Option to create Docker image and push to Quay

### DIFF
--- a/.github/workflows/deploy_tagged.yaml
+++ b/.github/workflows/deploy_tagged.yaml
@@ -71,6 +71,14 @@ jobs:
         env: 
           COLLAB_DEPLOY_TOKEN: ${{ secrets.COLLAB_DEPLOY_TOKEN }}
 
+      - name: Login to Quay.io
+        if: ${{ inputs.dockerize }}
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Dockerize
         if: ${{ inputs.dockerize }}
         uses: docker/build-push-action@v6

--- a/.github/workflows/deploy_tagged.yaml
+++ b/.github/workflows/deploy_tagged.yaml
@@ -7,6 +7,15 @@ on:
         description: 'patch and pre-release metadata'
         required: true
         default: '.0-alpha.1'
+      dockerize:
+        description: 'Whether to dockerize'
+        required: false
+        type: boolean
+        default: false
+      dockerTagPrefix:
+        description: 'Prefix for Docker tag, required if dockerize is true'
+        required: false
+        type: string
   workflow_call:
     inputs:
       changelist:
@@ -31,8 +40,7 @@ jobs:
 
     # Should only release tags
     # TODO: should only release tags where the required status checks are passing
-    # UNCOMMENT THIS FOR PR REVIEW!
-    # if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
 
     permissions:
       id-token: write
@@ -88,6 +96,7 @@ jobs:
         run: |
           DOCKER_TAG=${GITHUB_REF##refs/tags/}
           if [ $GITHUB_REF == $DOCKER_TAG ]; then
+            # Should never get here because of line 34, but leaving this just in case
             # If this isn't a tag, it must be a branch
             DOCKER_TAG=${GITHUB_REF##refs/heads/}
           fi

--- a/.github/workflows/deploy_tagged.yaml
+++ b/.github/workflows/deploy_tagged.yaml
@@ -22,6 +22,7 @@ on:
       dockerTagPrefix:
         description: 'Prefix for Docker tag, required if dockerize is true'
         required: false
+        type: string
 
 
 jobs:
@@ -84,7 +85,7 @@ jobs:
 
       - name: Set Docker tag name
         if: ${{ inputs.dockerize  && inputs.dockerTagPrefix != ''}}
-        run: 
+        run: |
           DOCKER_TAG=${GITHUB_REF##refs/tags/}
           if [ $GITHUB_REF == $DOCKER_TAG ]; then
             # If this isn't a tag, it must be a branch

--- a/.github/workflows/deploy_tagged.yaml
+++ b/.github/workflows/deploy_tagged.yaml
@@ -78,8 +78,7 @@ jobs:
         run: |
          git config --global user.email "${{ github.actor }}"
          git config --global user.name "${{ github.actor }}"
-         # Do not submit this for a PR
-         ./mvnw --batch-mode clean install -ntp -s .github/collab-mvn-settings.xml -DskipTests -Dchangelist=${{ github.event.inputs.changelist }}
+         ./mvnw --batch-mode deploy -ntp -s .github/collab-mvn-settings.xml -DskipTests -Dchangelist=${{ github.event.inputs.changelist }}
         env: 
           COLLAB_DEPLOY_TOKEN: ${{ secrets.COLLAB_DEPLOY_TOKEN }}
 

--- a/.github/workflows/deploy_tagged.yaml
+++ b/.github/workflows/deploy_tagged.yaml
@@ -7,13 +7,13 @@ on:
         description: 'patch and pre-release metadata'
         required: true
         default: '.0-alpha.1'
-      dockerize:
-        description: 'Whether to dockerize, caller must have Dockerfile in root of repo'
+      createDockerImage:
+        description: 'Whether to create a Docker image, caller must have Dockerfile in root of repo'
         required: false
         type: boolean
         default: false
       dockerTagPrefix:
-        description: 'Prefix for Docker tag, required if dockerize is true'
+        description: 'Prefix for Docker tag, required if createDockerImage is true'
         required: false
         type: string
   workflow_call:
@@ -23,13 +23,13 @@ on:
         required: true
         type: string
         default: '.0-alpha.1'  
-      dockerize:
-        description: 'Whether to dockerize, caller must have Dockerfile in root of repo'
+      createDockerImage:
+        description: 'Whether to create a Docker image, caller must have Dockerfile in root of repo'
         required: false
         type: boolean
         default: false
       dockerTagPrefix:
-        description: 'Prefix for Docker tag, required if dockerize is true'
+        description: 'Prefix for Docker tag, required if createDockerImage is true'
         required: false
         type: string
 
@@ -83,7 +83,7 @@ jobs:
           COLLAB_DEPLOY_TOKEN: ${{ secrets.COLLAB_DEPLOY_TOKEN }}
 
       - name: Login to Quay.io
-        if: ${{ inputs.dockerize  && inputs.dockerTagPrefix != ''}}
+        if: ${{ inputs.createDockerImage  && inputs.dockerTagPrefix != ''}}
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -91,7 +91,7 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Set Docker tag name
-        if: ${{ inputs.dockerize  && inputs.dockerTagPrefix != ''}}
+        if: ${{ inputs.createDockerImage && inputs.dockerTagPrefix != ''}}
         run: |
           DOCKER_TAG=${GITHUB_REF##refs/tags/}
           if [ $GITHUB_REF == $DOCKER_TAG ]; then
@@ -101,8 +101,8 @@ jobs:
           fi
           echo "DOCKER_TAG=${{ inputs.dockerTagPrefix }}:${DOCKER_TAG//\//_}" >> $GITHUB_ENV
 
-      - name: Dockerize
-        if: ${{ inputs.dockerize  && inputs.dockerTagPrefix != ''}}
+      - name: Create and push Docker image
+        if: ${{ inputs.createDockerImage  && inputs.dockerTagPrefix != ''}}
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/deploy_tagged.yaml
+++ b/.github/workflows/deploy_tagged.yaml
@@ -19,6 +19,9 @@ on:
         required: false
         type: boolean
         default: false
+      dockerTagPrefix:
+        description: 'Prefix for Docker tag, required if dockerize is true'
+        required: false
 
 
 jobs:
@@ -72,17 +75,27 @@ jobs:
           COLLAB_DEPLOY_TOKEN: ${{ secrets.COLLAB_DEPLOY_TOKEN }}
 
       - name: Login to Quay.io
-        if: ${{ inputs.dockerize }}
+        if: ${{ inputs.dockerize  && inputs.dockerTagPrefix != ''}}
         uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
 
+      - name: Set Docker tag name
+        if: ${{ inputs.dockerize  && inputs.dockerTagPrefix != ''}}
+        run: 
+          DOCKER_TAG=${GITHUB_REF##refs/tags/}
+          if [ $GITHUB_REF == $DOCKER_TAG ]; then
+            # If this isn't a tag, it must be a branch
+            DOCKER_TAG=${GITHUB_REF##refs/heads/}
+          fi
+          echo "DOCKER_TAG=${{dockerTagPrefix}}:${DOCKER_TAG//\//_}" >> $GITHUB_ENV
+
       - name: Dockerize
-        if: ${{ inputs.dockerize }}
+        if: ${{ inputs.dockerize  && inputs.dockerTagPrefix != ''}}
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
-          # tags: quay.io/dockstore/dockstore-support:${{env.S3_FOLDER}}
+          push: true
+          tags: ${{ env.DOCKER_TAG }}

--- a/.github/workflows/deploy_tagged.yaml
+++ b/.github/workflows/deploy_tagged.yaml
@@ -27,7 +27,8 @@ jobs:
 
     # Should only release tags
     # TODO: should only release tags where the required status checks are passing
-    if: startsWith(github.ref, 'refs/tags/')
+    # UNCOMMENT THIS FOR PR REVIEW!
+    # if: startsWith(github.ref, 'refs/tags/')
 
     permissions:
       id-token: write

--- a/.github/workflows/deploy_tagged.yaml
+++ b/.github/workflows/deploy_tagged.yaml
@@ -91,7 +91,7 @@ jobs:
             # If this isn't a tag, it must be a branch
             DOCKER_TAG=${GITHUB_REF##refs/heads/}
           fi
-          echo "DOCKER_TAG=${{dockerTagPrefix}}:${DOCKER_TAG//\//_}" >> $GITHUB_ENV
+          echo "DOCKER_TAG=${{ inputs.dockerTagPrefix }}:${DOCKER_TAG//\//_}" >> $GITHUB_ENV
 
       - name: Dockerize
         if: ${{ inputs.dockerize  && inputs.dockerTagPrefix != ''}}

--- a/.github/workflows/deploy_tagged.yaml
+++ b/.github/workflows/deploy_tagged.yaml
@@ -8,7 +8,7 @@ on:
         required: true
         default: '.0-alpha.1'
       dockerize:
-        description: 'Whether to dockerize'
+        description: 'Whether to dockerize, caller must have Dockerfile in root of repo'
         required: false
         type: boolean
         default: false
@@ -24,7 +24,7 @@ on:
         type: string
         default: '.0-alpha.1'  
       dockerize:
-        description: 'Whether to dockerize'
+        description: 'Whether to dockerize, caller must have Dockerfile in root of repo'
         required: false
         type: boolean
         default: false

--- a/.github/workflows/deploy_tagged.yaml
+++ b/.github/workflows/deploy_tagged.yaml
@@ -14,6 +14,11 @@ on:
         required: true
         type: string
         default: '.0-alpha.1'  
+      dockerize:
+        description: 'Whether to dockerize'
+        required: false
+        type: boolean
+        default: false
 
 
 jobs:
@@ -60,6 +65,15 @@ jobs:
         run: |
          git config --global user.email "${{ github.actor }}"
          git config --global user.name "${{ github.actor }}"
-         ./mvnw --batch-mode deploy -ntp -s .github/collab-mvn-settings.xml -DskipTests -Dchangelist=${{ github.event.inputs.changelist }}
+         # Do not submit this for a PR
+         ./mvnw --batch-mode clean install -ntp -s .github/collab-mvn-settings.xml -DskipTests -Dchangelist=${{ github.event.inputs.changelist }}
         env: 
           COLLAB_DEPLOY_TOKEN: ${{ secrets.COLLAB_DEPLOY_TOKEN }}
+
+      - name: Dockerize
+        if: ${{ inputs.dockerize }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          # tags: quay.io/dockstore/dockstore-support:${{env.S3_FOLDER}}


### PR DESCRIPTION
Updated the shared GitHub actions deploy workflow to optionally create a docker image and push it to quay.

Part of work for SEAB-6653. We'll create a Docker image from dockstore-support using this; the run a container from the image to do the topic updating.

**Review Instructions**

1. After the corresponding dockstore-support PR has been merged
2. Create a tag in dockstore-support
3. Run the deploy_workflow action in dockstore_support
4. After it completes, look at https://quay.io/repository/dockstore/dockstore-support?tab=tags to see if an image was created.