### PR TITLE
Use reusable image deploy from main branch

### DIFF
--- a/.github/workflows/deploy_artifacts.yaml
+++ b/.github/workflows/deploy_artifacts.yaml
@@ -113,7 +113,7 @@ jobs:
   deploy_image:
     needs: check_tag
     if: ${{ inputs.createDockerImage && inputs.quayRepository != '' }}
-    uses: dockstore/workflow-actions/.github/workflows/deploy_image.yaml@seab-6771/reusable-image-deploy
+    uses: dockstore/workflow-actions/.github/workflows/deploy_image.yaml@main
     with:
       quayRepository: ${{ inputs.quayRepository }}
       dockerContext: ${{ inputs.dockerContext }}


### PR DESCRIPTION
Follow-up to https://github.com/dockstore/workflow-actions/pull/3. The reusable deploy artifacts workflow calls the reusable deploy image workflow and I forgot to update the reference to the main branch. This PR fixes that.

https://ucsc-cgl.atlassian.net/browse/SEAB-6771