### PR TITLE
Pass changelist onto image deploy

### DIFF
--- a/.github/workflows/deploy_artifacts.yaml
+++ b/.github/workflows/deploy_artifacts.yaml
@@ -51,7 +51,7 @@ jobs:
             CHANGELIST_VERSION=${CHANGELIST_VERSION//\//-}
           fi
 
-          echo "changelist=${CHANGELIST_VERSION}" >> "$GITHUB_OUTPUT"      
+          echo "changelist=${DOESNT_EXIST}" >> "$GITHUB_OUTPUT"      
 
   deploy_maven:
     needs: set_changelist

--- a/.github/workflows/deploy_artifacts.yaml
+++ b/.github/workflows/deploy_artifacts.yaml
@@ -119,7 +119,7 @@ jobs:
   deploy_image:
     needs: set_changelist
     if: ${{ inputs.createDockerImage && inputs.quayRepository != '' }}
-    uses: dockstore/workflow-actions/.github/workflows/deploy_image.yaml@main
+    uses: dockstore/workflow-actions/.github/workflows/deploy_image.yaml@seab-6860/image-changelist
     with:
       quayRepository: ${{ inputs.quayRepository }}
       dockerContext: ${{ inputs.dockerContext }}

--- a/.github/workflows/deploy_artifacts.yaml
+++ b/.github/workflows/deploy_artifacts.yaml
@@ -23,8 +23,10 @@ env:
   IS_DEVELOP_SNAPSHOT: ${{ github.ref_type == 'branch' && github.ref_name == 'develop' }}
 
 jobs:
-  check_tag:
+  set_changelist:
     runs-on: ubuntu-22.04
+    outputs:
+      changelist: ${{ steps.set_changelist.outputs.changelist }}
     
     steps:
       - name: Check valid semantic tag
@@ -36,10 +38,28 @@ jobs:
             exit 1
           fi
 
+      - name: Set changelist version
+        id: set_changelist
+        run: |
+          set -x
+          if ${{ github.ref_type == 'tag' }}; then
+            # Break up the semantic version tag by the '.' delimiter and return the third field onward. Prefix this with the '.'
+            # Ex: 1.16.0 -> .0 and 1.16.0-alpha.0 -> .0-alpha.0
+            CHANGELIST_VERSION=.$(echo ${{ github.ref_name }} | cut -d. -f 3-)
+          elif ${{ github.ref_name != 'develop' }}; then
+            CHANGELIST_VERSION=.0-${{ github.ref_name }}-SNAPSHOT
+            CHANGELIST_VERSION=${CHANGELIST_VERSION//\//-}
+          fi
+
+          echo "changelist=${CHANGELIST_VERSION}" >> "$GITHUB_OUTPUT"      
+
   deploy_maven:
-    needs: check_tag
+    needs: set_changelist
     name: Maven deploy ${{ github.ref_type == 'tag' && 'tagged' || 'snapshot' }} release
     runs-on: ubuntu-22.04
+
+    env:
+      CHANGELIST_VERSION: ${{ needs.set_changelist.outputs.changelist }}
 
     steps:
       - uses: actions/checkout@v4
@@ -67,20 +87,6 @@ jobs:
           server-id: ${{ github.ref_type == 'tag' && 'central' || 'snapshots' }}
           server-username: DEPLOY_USERNAME
           server-password: DEPLOY_TOKEN
-
-      - name: Set changelist version
-        run: |
-          set -x
-          if ${{ github.ref_type == 'tag' }}; then
-            # Break up the semantic version tag by the '.' delimiter and return the third field onward. Prefix this with the '.'
-            # Ex: 1.16.0 -> .0 and 1.16.0-alpha.0 -> .0-alpha.0
-            CHANGELIST_VERSION=.$(echo ${{ github.ref_name }} | cut -d. -f 3-)
-          elif ${{ github.ref_name != 'develop' }}; then
-            CHANGELIST_VERSION=.0-${{ github.ref_name }}-SNAPSHOT
-            CHANGELIST_VERSION=${CHANGELIST_VERSION//\//-}
-          fi
-
-          echo "CHANGELIST_VERSION=${CHANGELIST_VERSION}" >> $GITHUB_ENV
 
       - name: Store Maven project version 
         run: |
@@ -111,10 +117,11 @@ jobs:
           DEPLOY_TOKEN: ${{ github.ref_type == 'tag' && secrets.COLLAB_DEPLOY_TOKEN  || secrets.SNAPSHOT_DEPLOY_TOKEN }}
 
   deploy_image:
-    needs: check_tag
+    needs: set_changelist
     if: ${{ inputs.createDockerImage && inputs.quayRepository != '' }}
     uses: dockstore/workflow-actions/.github/workflows/deploy_image.yaml@main
     with:
       quayRepository: ${{ inputs.quayRepository }}
       dockerContext: ${{ inputs.dockerContext }}
+      changelist: ${{ needs.set_changelist.outputs.changelist }}
     secrets: inherit

--- a/.github/workflows/deploy_artifacts.yaml
+++ b/.github/workflows/deploy_artifacts.yaml
@@ -51,7 +51,7 @@ jobs:
             CHANGELIST_VERSION=${CHANGELIST_VERSION//\//-}
           fi
 
-          echo "changelist=${DOESNT_EXIST}" >> "$GITHUB_OUTPUT"      
+          echo "changelist=${CHANGELIST_VERSION}" >> "$GITHUB_OUTPUT"      
 
   deploy_maven:
     needs: set_changelist

--- a/.github/workflows/deploy_artifacts.yaml
+++ b/.github/workflows/deploy_artifacts.yaml
@@ -119,7 +119,7 @@ jobs:
   deploy_image:
     needs: set_changelist
     if: ${{ inputs.createDockerImage && inputs.quayRepository != '' }}
-    uses: dockstore/workflow-actions/.github/workflows/deploy_image.yaml@seab-6860/image-changelist
+    uses: dockstore/workflow-actions/.github/workflows/deploy_image.yaml@main
     with:
       quayRepository: ${{ inputs.quayRepository }}
       dockerContext: ${{ inputs.dockerContext }}

--- a/.github/workflows/deploy_image.yaml
+++ b/.github/workflows/deploy_image.yaml
@@ -12,6 +12,10 @@ on:
         required: false
         default: .
         type: string
+      changelist:
+        description: 'Patch and pre-release metadata. Example: ".0-alpha.1"'
+        required: false
+        type: string
 
 env:
   DOCKER_IMAGE_NAME: quay.io/dockstore/${{ inputs.quayRepository }}
@@ -56,8 +60,14 @@ jobs:
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
 
-      - name: Build
+      - name: Build without changelist
+        if: ${{ inputs.changelist == '' }}
         run: ./mvnw -B clean install -DskipTests
+
+      - name: Build with changelist
+        if: ${{ inputs.changelist != '' }}
+        run: |
+          ./mvnw -B clean install -DskipTests -Dchangelist=${{ inputs.changelist }}
 
       - name: Set folder name
         run: |


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-6860

The deploy image workflow wasn't building with `-Dchangelist` which affected the version number in the staging deploy (see ticket for details). This PR adds a changelist input to the image deploy workflow. The deploy artifacts workflow has a `set_changelist` job that sets a `changelist` output value that is then used by the downstream `deploy_artifacts` and `deploy_image` jobs. Read more about outputs [here](https://docs.github.com/en/enterprise-server@3.11/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs#overview) if interested.

Note to self:
- [x] Update the reusable image workflow reference from below to main BEFORE merging