### PR TITLE
Add build args input for deploy_image.yaml

### DIFF
--- a/.github/workflows/deploy_image.yaml
+++ b/.github/workflows/deploy_image.yaml
@@ -12,6 +12,10 @@ on:
         required: false
         default: .
         type: string
+      buildArgs:
+        description: Build arguments used to build the Docker image
+        required: false
+        type: string
       changelist:
         description: 'Patch and pre-release metadata. Example: ".0-alpha.1"'
         required: false
@@ -81,6 +85,8 @@ jobs:
           context: ${{ inputs.dockerContext }}
           push: true
           tags: '${{ env.DOCKER_IMAGE_NAME }}:${{ env.S3_FOLDER }}'
+          build-args: |
+            ${{ inputs.buildArgs }}
 
       - name: Create checksums
         run: |


### PR DESCRIPTION
As part of https://ucsc-cgl.atlassian.net/browse/SEAB-6836, the Dockerfile in https://github.com/dockstore/dockstore-deploy/pull/818 requires build arguments to be provided. 

This PR modifies the reusable image deploy workflow so that it takes an optional `buildArgs` input.